### PR TITLE
Update Audi S5 generations: Add separate facelift entries and new B10 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi S5
 
+This repository contains signal set configurations for the Audi S5, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi S5.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,10 +1,28 @@
-generations:
-  - name: "First Generation (8T)"
-    start_year: 2007
-    end_year: 2016
-    description: "The original Audi S5 was based on the first-generation A5 platform, initially featuring a naturally aspirated 4.2L V8 engine producing 354 HP in the coupe, while the later introduced cabriolet and sportback variants received a supercharged 3.0L V6. The coupe was also updated to the V6 with its 2012 facelift. Transmission options included a six-speed manual or automatic for the V8, and a seven-speed S tronic dual-clutch for the V6. The S5 featured distinctive styling with subtle S-specific enhancements, including aluminum-look mirror caps, quad exhaust tips, and unique wheels. The first-generation S5 was praised for its balance of performance, luxury, and striking design."
+references:
+  - "https://en.wikipedia.org/wiki/Audi_S5"
 
-  - name: "Second Generation (F5)"
-    start_year: 2016
+generations:
+  - name: "First Generation (B8/8T)"
+    start_year: 2007
+    end_year: 2012
+    description: "The original Audi S5 was released in coupé form alongside the A5. The B8 generation featured a 4.2-litre V8 FSI engine in the coupé producing 260 kW (354 HP), while the cabriolet and sportback variants (introduced in 2009) received a supercharged 3.0-litre V6 TFSI engine producing 245 kW. The coupé offered a 6-speed manual or Tiptronic automatic, while the cabriolet and sportback had a 7-speed S-tronic dual-clutch transmission. The S5 featured distinctive aggressive styling with LED daytime running lights, bi-Xenon headlamps, and dual-tip exhausts."
+
+  - name: "First Generation (B8.5/8.5T Facelift)"
+    start_year: 2012
+    end_year: 2017
+    description: "The B8.5 facelift represented a mid-generational refresh with significant styling updates including a complete redesign of the headlights with new LED DRL's, a new grille based on the A6 design, and updated LED tail lights. Most notably, the coupé switched from the 4.2L V8 to the 3.0-litre supercharged V6 TFSI engine, unifying the powertrain across all body styles. Stop-start technology was introduced for improved fuel efficiency. Interior updates included chrome-treated dials, new Audi MMI 3G+ with Google Earth maps, and a flat-bottom steering wheel style."
+
+  - name: "Second Generation (B9)"
+    start_year: 2017
+    end_year: 2024
+    description: "The B9 generation, built from late 2017, introduced a completely new 3.0-litre V6 twin-scroll turbocharged engine co-developed with Porsche, producing 260 kW and mounted with the turbo within the V-angle to reduce turbo lag. Major design changes included a complete redesign of the headlights, bonnet, sharper body lines, and a new larger one-piece grille with LED front and rear lighting. The quattro system utilized a locking centre differential splitting torque 40% front/60% rear with variable distribution. Interior featured a redesigned dashboard, updated 8-inch Audi MMI, optional Virtual Cockpit, and electrically adjustable heated sport seats."
+
+  - name: "Second Generation (B9.5 Facelift)"
+    start_year: 2019
+    end_year: 2024
+    description: "The 2019 B9.5 facelift introduced for 2020 model year featured updated styling and powertrain options. In Europe, the new 2019 S5 was exclusively offered with a diesel V6 TDI engine producing 345 HP as a mild-hybrid variant, while other markets retained the 3.0L TFSI twin-scroll turbocharged engine. This generation maintained the advanced technology features and performance credentials of the B9."
+
+  - name: "Third Generation (B10)"
+    start_year: 2024
     end_year: null
-    description: "Based on the second-generation A5 platform, the current S5 features a turbocharged 3.0L V6 engine producing 349 HP (later 341 HP in some markets), paired with an eight-speed automatic transmission and quattro all-wheel drive. Available in coupe, sportback, and cabriolet body styles, it features more aggressive styling than its predecessor with sharper lines and more pronounced details. The interior blends performance-oriented features with Audi's latest technology including the Virtual Cockpit digital instrument cluster. A facelift in 2019 updated the styling with a wider, flatter grille and revised details. The second-generation S5 continues to offer an appealing combination of performance, luxury, and distinctive styling across all three body variants, positioned between the standard A5 and the high-performance RS5."
+    description: "The latest B10 generation is based on the new Audi A5 B10 and uses the Premium Platform Combustion (PPC). The B10 S5 introduces a new 3.0-litre V6 twin-scroll MHEV (mild hybrid electric vehicle) turbocharged engine producing 270 kW and 550 Nm of torque. For the first time, the S5 is available as a sedan and as an Avant estate/wagon in addition to the traditional coupé and cabriolet variants, significantly expanding the model's appeal and versatility."


### PR DESCRIPTION
- Added B8/8T (2007-2012) as separate first generation entry with V8 and V6 powertrains
- Added B8.5/8.5T Facelift (2012-2017) as distinct generation capturing mid-cycle refresh with unified V6 powertrain
- Renamed second generation to B9 (2017-2024) with new twin-scroll turbocharged engine
- Added B9.5 Facelift (2019-2024) with diesel option for European markets
- Added new B10 Third Generation (2024-present) on PPC platform with MHEV technology and new Avant body style
- Added Wikipedia reference to infobox
- Updated descriptions with specific engine codes, power outputs, and design details from Wikipedia

Wikipedia evidence:
- Infobox: Production 2007-present, platforms MLB/MLP (2007-2024) and PPC (2024-present)
- B8/8T: "The Audi S5 was released in coupé form...initially featuring a naturally aspirated 4.2L V8"
- B8.5 Facelift: "The (B8.5/8.5T or Facelift) Audi S5 went through a mid-generational refresh"
- B9: "The Audi S5 (B9) is an all-wheel drive coupé, sportback, & cabriolet built by Audi from late 2017"
- B9.5 Facelift: "In 2019, Audi introduced a new facelifted version of the B9 for the 2020 models, the B9.5"
- B10: "The Audi S5 B10 is based on the Audi A5 B10"

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
